### PR TITLE
Fix to ensure multiple content-types don't get added to request heade…

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -132,8 +132,10 @@
         }
 
         xhr.open(method, url);
-        xhr.setRequestHeader('Content-type',
-                             'application/x-www-form-urlencoded');
+        if (!headers.hasOwnProperty('Content-type')) {
+            xhr.setRequestHeader('Content-type',
+                                 'application/x-www-form-urlencoded');
+        }
         for (var h in headers) {
             if (headers.hasOwnProperty(h)) {
                 xhr.setRequestHeader(h, headers[h]);


### PR DESCRIPTION
…r when specifying a header of type "Content-type" through the AJAX functions.

Note: multiple content-types were only getting created in Chrome as far
as I could tell (firefox and fiddler reported a single content-type).
